### PR TITLE
Fix CHB "This channel has guests" accessibility

### DIFF
--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -278,10 +278,12 @@ class ChannelHeader extends React.PureComponent {
         if (hasGuests) {
             hasGuestsText = (
                 <span className='has-guest-header'>
-                    <FormattedMessage
-                        id='channel_header.channelHasGuests'
-                        defaultMessage='This channel has guests'
-                    />
+                    <span tabIndex={0}>
+                        <FormattedMessage
+                            id='channel_header.channelHasGuests'
+                            defaultMessage='This channel has guests'
+                        />
+                    </span>
                 </span>
             );
         }


### PR DESCRIPTION
#### Summary
Fix Jaws does not TAB to or read "This channel has guests" in the channel header bar.

A new span tag was added to avoid screen reader to say the css ::after pseudo-element.
Otherwise, the screen reader would say: "This channel has guests, bullet"

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32589)

#### Release Note
```release-note
NONE
```
